### PR TITLE
イベント詳細ページを追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,8 @@ $fotter-color: #322D2A;
 $non-active-cplor: #C5B5A6;
 $active-color: #E6D177;
 $bace-color: #F4E2CA;
+$form-color: #E9ECEF;
+$form-text-color: #495057;
 
 .base-container {
   @extend .container-fluid;
@@ -66,7 +68,54 @@ $bace-color: #F4E2CA;
   border-radius: 4px;
 }
 
+.event-top {
+  margin-top: 30px;
+}
+
 .name-label {
   background-color: $bace-color;
   border-radius: 4px;
 }
+
+.table-ditale {
+  margin-bottom: 40px;
+}
+
+table {
+  width: 100%;
+  border-top: 1px solid $form-color;
+  border-right: 1px solid $form-color;
+
+
+  th {
+    width: 30%;
+    background-color: $form-color;
+    box-sizing: border-box;
+    padding: 15px;
+    font-weight: normal;
+    text-align: center;
+    color: $form-text-color;
+
+    &:first-of-type {
+      border-bottom: 1px solid #fff;
+    }
+  }
+
+  td {
+    text-align: left;
+    box-sizing: border-box;
+    padding: 15px;
+    border-bottom: 1px solid $form-color;
+  }
+}
+
+.event-detaile {
+  border-radius: 4px;
+  border: 1px solid $form-color;
+
+  .event-title {
+    background-color: $form-color;
+    padding: 7px;
+  }
+}
+

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -23,7 +23,7 @@ class EventsController < ApplicationController
 
   def create
     event = current_user.events.create!(event_params)
-    # Join.create!(user_id: current_user.id, event_id: event.id)
+    Join.create!(user_id: current_user.id, event_id: event.id)
     redirect_to action: :index
   end
 

--- a/app/controllers/joins_controller.rb
+++ b/app/controllers/joins_controller.rb
@@ -1,0 +1,23 @@
+class JoinsController < ApplicationController
+
+  before_action :check_others_event
+
+  def create
+    current_user.joins.create!(event_id: params[:event_id])
+    redirect_to event_path(id: params[:event_id])
+  end
+
+  def destroy
+    current_user.joins.find_by(event_id: params[:event_id]).destroy!
+    redirect_to event_path(id: params[:event_id])
+  end
+
+  private
+
+  def check_others_event
+    if Event.find(params[:event_id]).user_id == current_user.id
+      redirect_to root_path
+    end
+  end
+
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,7 +1,11 @@
 class Event < ApplicationRecord
   belongs_to :user
+  has_many :joins, dependent: :destroy
+  # event.joined_users で参加しているユーザー一覧が取得できるようになる
+  has_many :joined_users, through: :joins, source: :user
 
   validates :title, :venue, :datetime, :content,  presence: true
+
   mount_uploader :event_image, EventImageUploader
 
 end

--- a/app/models/join.rb
+++ b/app/models/join.rb
@@ -1,0 +1,6 @@
+class Join < ApplicationRecord
+  belongs_to :user
+  belongs_to :event
+  validates :user_id, presence: true, uniqueness: { scope: :event_id }
+  validates :event_id, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,9 @@ class User < ApplicationRecord
 
 
   has_many :events, dependent: :destroy
+  has_many :joins, dependent: :destroy
+   # user.joined_events で user が参加しているイベント一覧が取得できるようになる
+   has_many :joined_events, through: :joins, source: :message
 
   mount_uploader :image, ImageUploader
   # ユーザーをuidで検索する。無ければproviderから情報を取得し作成する。

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,0 +1,72 @@
+<div>
+  <% unless @event.user == current_user %>
+    <% if @event.joins.exists?(user_id: current_user.id) %>
+      <%= link_to 'キャンセル', event_joins_path(@event), method: :delete, class: "btn btn-danger btn-block" %>
+    <% else %>
+      <%= link_to '参加する', event_joins_path(@event), method: :post, class: "btn btn-primary btn-block" %>
+    <% end %>
+  <% end %>
+
+  <p>
+    <% if @event.user == current_user %>
+      <%= link_to "削除", event_path(@event), method: :delete, data: { confirm: "削除しますか？" } %>
+      <%= link_to "編集", edit_event_path(@event) %>
+    <% end %>
+  </p>
+</div>
+
+<div class="mb-3 event-top">
+  <h3><%= @event.title %></h3>
+  <%= image_tag @event.event_image_url, size: '500x350', alt: "event image", class:"img-fluid rounded mx-auto d-block" %>
+</div>
+
+<div class="mb-3">
+  <table class="content">
+    <tr>
+      <th>日時</th>
+      <td><%= l @event.datetime, format: '%Y年 %-m月 %-d日 %H:%M' %></td>
+    </tr>
+    <tr>
+      <th>開催場所</th>
+      <td><%= @event.venue %></td>
+    </tr>
+    <tr>
+      <th>参加者</th>
+      <td>
+        <% @event.joined_users.each do |participant| %>
+          <a href="<%= user_path(participant) %>">
+            <%= image_tag participant.image_url, :size => '20x20', class: "mr-1" %>
+          </a>
+        <% end %>
+      </td>
+    </tr>
+  </table>
+</div>
+
+<div class="event-detaile mb-3">
+  <h6 class="event-title">イベント詳細</h6>
+  <span class="detale-body"><%= markdown(@event.content).html_safe %></span>
+</div>
+
+<div>
+  <% unless @event.user == current_user %>
+    <% if @event.joins.exists?(user_id: current_user.id) %>
+      <%= link_to 'キャンセル', event_joins_path(@event), method: :delete, class: "btn btn-danger btn-block" %>
+    <% else %>
+      <%= link_to '参加する', event_joins_path(@event), method: :post, class: "btn btn-primary btn-block" %>
+    <% end %>
+  <% end %>
+
+  <p>
+    <% if @event.user == current_user %>
+      <%= link_to "削除", event_path(@event), method: :delete, data: { confirm: "削除しますか？" } %>
+      <%= link_to "編集", edit_event_path(@event) %>
+    <% end %>
+  </p>
+</div>
+
+
+<div>
+  <%= link_to 'トークルーム', "/events/#{@event.id}/chat_room", class: "btn btn-primary btn-block" %>
+</div>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,7 @@ Rails.application.routes.draw do
   }
   resources :users, only: [:show, :edit, :update]
   patch '/users/:id/user_update', to: 'users#user_update'
-  resources :events
+  resources :events do
+    resource :joins, only: [:create, :destroy]
+  end
 end

--- a/db/migrate/20200522073945_join.rb
+++ b/db/migrate/20200522073945_join.rb
@@ -1,0 +1,12 @@
+class Join < ActiveRecord::Migration[6.0]
+  def change
+    create_table :joins do |t|
+      t.integer :user_id, null: false, index: true
+      t.integer :event_id, null: false, index: true
+
+      t.timestamps
+    end
+
+    add_index :joins, [:user_id, :event_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_19_073816) do
+ActiveRecord::Schema.define(version: 2020_05_22_073945) do
 
   create_table "events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "title", null: false
@@ -22,6 +22,16 @@ ActiveRecord::Schema.define(version: 2020_05_19_073816) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_events_on_user_id"
+  end
+
+  create_table "joins", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "event_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["event_id"], name: "index_joins_on_event_id"
+    t.index ["user_id", "event_id"], name: "index_joins_on_user_id_and_event_id", unique: true
+    t.index ["user_id"], name: "index_joins_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|


### PR DESCRIPTION
## 内容
- イベント参加機能の実装
- イベント詳細画面の実装

## 詳細
- イベント参加機能の実装
  - Joinテーブルを追加
  - Join用にUserモデルとEventモデルにhas_many :joinsを追加
  - Joinのルート，コントローラーを追加
  - event_controller.rb の createアクションにカレントユーザーをJoinに登録するコードを追加
- イベント詳細画面の実装
  - events/show.html.rbを追加
  - stylesheets/application.scssに追記