### PR TITLE
イベント登録フォームの英字を日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'mysql2', '>= 0.4.4'
 gem "puma", ">= 4.3.5"
 gem 'sass-rails', '>= 6'
 gem 'webpacker', '~> 4.0'
-# gem 'turbolinks', '~> 5'
+gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.7'
 gem 'bootsnap', '>= 1.4.2', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,6 +272,9 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
+    turbolinks (5.2.1)
+      turbolinks-source (~> 5.2)
+    turbolinks-source (5.2.0)
     twitter (7.0.0)
       addressable (~> 2.3)
       buftok (~> 0.2.0)
@@ -336,6 +339,7 @@ DEPENDENCIES
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)
+  turbolinks (~> 5)
   twitter
   tzinfo-data
   unicorn

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,7 +4,7 @@
 // that code so it'll be compiled.
 
 require("@rails/ujs").start()
-// require("turbolinks").start()
+require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -23,10 +23,10 @@
     </div>
 
     <div class="form-group">
-      <%= form.label :image, class: 'control-label' %>
+      <%= form.label :event_image, class: 'control-label' %>
       <div class="custom-file">
         <%= form.file_field :image, class: 'custom-file-input', id: "inputFile" %>
-        <label class="custom-file-label" for="inputFile">ファイルを選択して下さい</label>
+        <label class="custom-file-label" for="inputFile" data-browse="参照" >ファイルを選択して下さい</label>
       </div>
     </div>
 

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -26,7 +26,7 @@
       <%= form.label :event_image, class: 'control-label' %>
       <div class="custom-file">
         <%= form.file_field :event_image, class: 'custom-file-input', id: "inputFile" %>
-        <label class="custom-file-label" for="inputFile">ファイルを選択して下さい</label>
+        <label class="custom-file-label" for="inputFile" data-browse="参照">ファイルを選択して下さい</label>
       </div>
     </div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,9 +8,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_pack_tag 'application' %>
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-
+    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 
   <body>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -32,7 +32,7 @@ ja:
         title: タイトル
         venue: 開催地
         datetime: 開催日時
-        image: 画像
+        event_image: 画像
         content: 内容
     models:
       user: ユーザ

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "jquery": "^3.5.1",
     "moment": "^2.25.3",
     "popper.js": "^1.16.1",
-    "tempusdominus-bootstrap-4": "^5.1.2"
+    "tempusdominus-bootstrap-4": "^5.1.2",
+    "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7048,6 +7048,11 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+turbolinks@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/turbolinks/-/turbolinks-5.2.0.tgz#e6877a55ea5c1cb3bb225f0a4ae303d6d32ff77c"
+  integrity sha512-pMiez3tyBo6uRHFNNZoYMmrES/IaGgMhQQM+VFF36keryjb5ms0XkVpmKHkfW/4Vy96qiGW3K9bz0tF5sK9bBw==
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"


### PR DESCRIPTION
## 内容
JSがうまく作動しない原因がアプリではなくNginxの設定ミスだった。
- Turbolinksの設定をもとに戻した。
- イベント作成と編集の画像投稿フォームの英字を日本語にした。